### PR TITLE
Fix invalid uuid

### DIFF
--- a/config.json
+++ b/config.json
@@ -51,7 +51,7 @@
         "map"
       ],
       "unlocked_by": null,
-      "uuid": "612f5f98-09a6-9d80-5820-edeec5ce1e1544073ed"
+      "uuid": "06242da7-4796-482a-a467-358b22128c32"
     }
   ],
   "foregone": [],


### PR DESCRIPTION
Configlet previously could generate invalid uuids.

The `accumulate` exercise here seems to have an invalid uuid.