### PR TITLE
Update Travis build to use configlet subcommand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ install:
   - "[[ $(which idris) != '' ]] || travis_wait 60 stack --resolver $RESOLVER install idris"
 
 script:
-  - bin/configlet .
+  - bin/configlet lint .
   - bin/solve_exercises.sh


### PR DESCRIPTION
The configlet command changed a while back. I thought I had updated all the tracks to the new version of the command, but I appear to have missed this one.