### PR TITLE
Accumulate: allow more generic implementations

### DIFF
--- a/exercises/accumulate/src/Example.idr
+++ b/exercises/accumulate/src/Example.idr
@@ -1,6 +1,6 @@
 module Accumulate
 
 export
-accumulate : (Int -> Int) -> List Int -> List Int
+accumulate : (a -> b) -> List a -> List b
 accumulate f [] = []
 accumulate f (x::xs) = f x :: accumulate f xs

--- a/exercises/accumulate/src/Test/Accumulate.idr
+++ b/exercises/accumulate/src/Test/Accumulate.idr
@@ -8,7 +8,7 @@ assertEq : Eq a => String -> (given : a) -> (expected : a) -> IO ()
 assertEq label g e = putStrLn $ if g == e then label ++ ": Test Passed" else label ++ ": Test Failed"
 
 testEmptyListDoesNothing : IO ()
-testEmptyListDoesNothing = assertEq "empty list does nothing" (accumulate (\x => x) []) []
+testEmptyListDoesNothing = assertEq "empty list does nothing" (accumulate (\x => x) []) (the (List Int) [])
 
 testIdentityFunctionDoesNothing : IO ()
 testIdentityFunctionDoesNothing = assertEq "identity function does nothing" (accumulate (\x => x) [1,2,3]) [1,2,3]
@@ -23,7 +23,7 @@ testIncrementFunctionAddsOneToAllInput : IO ()
 testIncrementFunctionAddsOneToAllInput = assertEq "increment function adds 1 to input" (accumulate (\x => x + 1) [1,2,3]) [2,3,4]
 
 testDecrementFunctionAddsOneToAllInput : IO ()
-testDecrementFunctionAddsOneToAllInput = assertEq "decrement function subtracts 1 from input" (accumulate (\x => x - 1) [1,2,3]) [0,1,2]
+testDecrementFunctionAddsOneToAllInput = assertEq "decrement function subtracts 1 from input" (accumulate (\x => x - 1) [1,2,3]) (the (List Int) [0,1,2])
 
 runTests : IO ()
 runTests = do


### PR DESCRIPTION
This fixes #45 by using a more specific `assertEq`.