### PR TITLE
Reformat config files

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,75 +1,64 @@
 {
+  "language": "Idris",
   "active": false,
-  "deprecated": [
-
-  ],
-  "foregone": [
-
-  ],
+  "blurb": "",
   "exercises": [
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "rna-transcription",
-      "topics" : [
+      "uuid": "3640da6c-4f1d-483c-8990-de225fcb0b03",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
         "pattern_matching",
         "vectors"
-      ],
-      "unlocked_by": null,
-      "uuid": "3640da6c-4f1d-483c-8990-de225fcb0b03"
+      ]
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "hello-world",
+      "uuid": "b4b0db87-75a2-4c81-897f-b27d1fd4a7d6",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
         "optional_values",
         "text_formatting"
-      ],
-      "unlocked_by": null,
-      "uuid": "b4b0db87-75a2-4c81-897f-b27d1fd4a7d6"
+      ]
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "leap",
+      "uuid": "2c7ab2e7-d87a-41ee-a81e-7572d7872562",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
         "arithmetic",
         "booleans",
         "integers"
-      ],
-      "unlocked_by": null,
-      "uuid": "2c7ab2e7-d87a-41ee-a81e-7572d7872562"
+      ]
     },
     {
-      "core": false,
-      "difficulty": 2,
       "slug": "hamming",
+      "uuid": "7a1d481f-7f45-4646-81bc-7ca3c8cb5eb0",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
         "export_modifiers",
         "vectors"
-      ],
-      "unlocked_by": null,
-      "uuid": "7a1d481f-7f45-4646-81bc-7ca3c8cb5eb0"
+      ]
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "accumulate",
+      "uuid": "06242da7-4796-482a-a467-358b22128c32",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
         "functions",
         "lists",
         "map"
-      ],
-      "unlocked_by": null,
-      "uuid": "06242da7-4796-482a-a467-358b22128c32"
+      ]
     }
-  ],
-  "foregone": [],
-  "ignored": [
-    "_src",
-    "bin",
-    "docs"
-  ],
-  "language": "Idris"
+  ]
 }

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -2,14 +2,14 @@
   "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md",
   "maintainers": [
     {
-      "alumnus": false,
-      "avatar_url": null,
-      "bio": null,
       "github_username": "yurrriq",
+      "alumnus": false,
+      "show_on_website": false,
+      "name": null,
       "link_text": null,
       "link_url": null,
-      "name": null,
-      "show_on_website": false
+      "avatar_url": null,
+      "bio": null
     }
   ]
 }


### PR DESCRIPTION
This runs the configlet fmt command, which normalizes the
contents and ordering of keys in the track config and
maintainers config.

This will let us script changes to the config files without
having unnecessary noise in the diffs when submitting pull
requests.

See exercism/meta#95