### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Idris is a general purpose pure functional programming language with [dependent types](http://en.wikipedia.org/wiki/Dependent_type). 
 Dependent types allow types to be predicated on values, 
 meaning that some aspects of a program’s behaviour can be specified precisely in the type. 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 ## Prerequisites
 
 Before installing Idris, you will need to make sure you have all of the necessary libraries and tools. You will need:

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,4 +1,4 @@
-## [The official documentation](http://docs.idris-lang.org/en/latest/index.html)
+# [The official documentation](http://docs.idris-lang.org/en/latest/index.html)
 
 This tutorial is intended as a brief introduction to the language, 
 and is aimed at readers already familiar with a functional language such as Haskell or OCaml. 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,4 +1,4 @@
-## Useful resources
+# Useful resources
 
  * The [official homepage](http://www.idris-lang.org/) and [documentation](http://docs.idris-lang.org/en/latest/index.html)
  * The [Github repository](https://github.com/idris-lang/Idris-dev)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 ## GNU Make
 
 There is a `Makefile` provided with every exercise, so it is sufficient to simply run


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
