### PR TITLE
🤖 Add blurb to .meta/config.json files

### DIFF
--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a year, report if it is a leap year.",
   "authors": [],
   "files": {
     "solution": [],

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [],
   "files": {
     "solution": [],


### PR DESCRIPTION
Each Concept and Practice Exercise will have to define a _blurb_, which is a short description of the exercise.
The blurb will be displayed on a track's exercises page and on exercise tooltips. For example:

<img width="1194" alt="Screenshot 2021-03-02 at 13 25 38" src="https://user-images.githubusercontent.com/286476/109655154-da058500-7b5a-11eb-8346-bf733a72b3d0.png">
<img width="400" alt="Screenshot 2021-03-02 at 13 25 51" src="https://user-images.githubusercontent.com/286476/109655162-dd007580-7b5a-11eb-88f8-582532be9b84.png">

Blurbs must be limited to 350 chars and will be truncated in some views.

For Practice Exercises that are based on an exercise defined in the problem-specification repo, the blurb must match the contents of the problem-specifications exercises, which is defined in its `metadata.yml` file. In this PR, we'll do an initial syncing of the blurb. The new [configlet](https://github.com/exercism/configlet) version will add support for doing this syncing automatically.

If the Practice Exercise was _not_ based on a problems-specifications exercise, we've used the blurb from its `.meta/metadata.yml` file as the blurb in the .meta/config.json file.

See the [Practice Exercise spec](https://github.com/exercism/docs/blob/main/anatomy/tracks/practice-exercises.md#file-metaconfigjson) for more information.

## Tracking

https://github.com/exercism/v3-launch/issues/21
