### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "9a2f2729-ac5c-4570-aa43-26381ca02440",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Idris locally",
+      "blurb": "Learn how to install Idris locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "0c6fc185-39fe-40d2-9ba7-28a90da81748",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Idris",
+      "blurb": "An overview of how to get started from scratch with Idris"
+    },
+    {
+      "uuid": "09a30fbe-c488-4e89-a233-21c305998627",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Idris track",
+      "blurb": "Learn how to test your Idris exercises on Exercism"
+    },
+    {
+      "uuid": "cc915bf6-5f23-44c8-9f0b-4b3fe01538a1",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Idris resources",
+      "blurb": "A collection of useful resources to help you master Idris"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
