### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/src/HelloWorld.idr
+++ b/exercises/practice/hello-world/src/HelloWorld.idr
@@ -2,7 +2,7 @@ module HelloWorld
 
 export
 hello : String
-hello = ?hello_rhs
+hello = "Goodbye, Mars!"
 
 export
 version : String


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46