### PR TITLE
Add reverse-string

### DIFF
--- a/config.json
+++ b/config.json
@@ -70,6 +70,14 @@
         ]
       },
       {
+        "slug": "reverse-string",
+        "name": "Reverse String",
+        "uuid": "394b00eb-2d53-483e-b403-982400c58ea6",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
+      },
+      {
         "slug": "rna-transcription",
         "name": "Rna Transcription",
         "uuid": "3640da6c-4f1d-483c-8990-de225fcb0b03",

--- a/exercises/practice/reverse-string/.docs/instructions.append.md
+++ b/exercises/practice/reverse-string/.docs/instructions.append.md
@@ -1,0 +1,6 @@
+# Instructions append
+
+## Restrictions
+
+Keep your hands off that `reverse` function provided by the prelude!
+Solve this one yourself using other basic tools instead.

--- a/exercises/practice/reverse-string/.docs/instructions.md
+++ b/exercises/practice/reverse-string/.docs/instructions.md
@@ -1,0 +1,9 @@
+# Instructions
+
+Your task is to reverse a given string.
+
+Some examples:
+
+- Turn `"stressed"` into `"desserts"`.
+- Turn `"strops"` into `"sports"`.
+- Turn `"racecar"` into `"racecar"`.

--- a/exercises/practice/reverse-string/.docs/introduction.md
+++ b/exercises/practice/reverse-string/.docs/introduction.md
@@ -1,0 +1,5 @@
+# Introduction
+
+Reversing strings (reading them from right to left, rather than from left to right) is a surprisingly common task in programming.
+
+For example, in bioinformatics, reversing the sequence of DNA or RNA strings is often important for various analyses, such as finding complementary strands or identifying palindromic sequences that have biological significance.

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "src/ReverseString.idr"
+    ],
+    "test": [
+      "test/src/Main.idr"
+    ],
+    "example": [
+      "example/ReverseString.idr"
+    ]
+  },
+  "blurb": "Reverse a given string.",
+  "source": "Introductory challenge to reverse an input string",
+  "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"
+}

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,0 +1,39 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c3b7d806-dced-49ee-8543-933fd1719b1c]
+description = "an empty string"
+
+[01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
+description = "a word"
+
+[0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
+description = "a capitalized word"
+
+[71854b9c-f200-4469-9f5c-1e8e5eff5614]
+description = "a sentence with punctuation"
+
+[1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
+description = "a palindrome"
+
+[b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
+description = "an even-sized word"
+
+[1bed0f8a-13b0-4bd3-9d59-3d0593326fa2]
+description = "wide characters"
+
+[93d7e1b8-f60f-4f3c-9559-4056e10d2ead]
+description = "grapheme cluster with pre-combined form"
+include = false
+
+[1028b2c1-6763-4459-8540-2da47ca512d9]
+description = "grapheme clusters"
+include = false

--- a/exercises/practice/reverse-string/example/ReverseString.idr
+++ b/exercises/practice/reverse-string/example/ReverseString.idr
@@ -1,0 +1,8 @@
+module ReverseString
+
+export
+rev : String -> String
+rev = pack . reverseList [] . unpack
+where reverseList : List Char -> List Char -> List Char
+      reverseList suffix [] = suffix
+      reverseList suffix (x :: xs) = reverseList (x :: suffix) xs

--- a/exercises/practice/reverse-string/pack.toml
+++ b/exercises/practice/reverse-string/pack.toml
@@ -1,0 +1,10 @@
+[custom.all.reverse-string]
+type = "local"
+path = "."
+ipkg = "reverse-string.ipkg"
+test = "test/test.ipkg"
+
+[custom.all.reverse-string-test]
+type = "local"
+path = "test"
+ipkg = "test.ipkg"

--- a/exercises/practice/reverse-string/reverse-string.ipkg
+++ b/exercises/practice/reverse-string/reverse-string.ipkg
@@ -1,0 +1,3 @@
+package reverse-string
+modules = ReverseString
+sourcedir = "src"

--- a/exercises/practice/reverse-string/src/ReverseString.idr
+++ b/exercises/practice/reverse-string/src/ReverseString.idr
@@ -1,0 +1,5 @@
+module ReverseString
+
+export
+rev : String -> String
+rev = ?rev_rhs

--- a/exercises/practice/reverse-string/test/src/Main.idr
+++ b/exercises/practice/reverse-string/test/src/Main.idr
@@ -1,0 +1,28 @@
+module Main
+
+import System
+import Tester
+import Tester.Runner
+
+import ReverseString
+
+tests : List Test
+tests =
+  [ test "an empty string"             (assertEq (rev "") "")
+  , test "a word"                      (assertEq (rev "robot") "tobor")
+  , test "a capitalized word"          (assertEq (rev "Ramen") "nemaR")
+  , test "a sentence with punctuation" (assertEq (rev "I'm hungry!") "!yrgnuh m'I")
+  , test "a palindrome"                (assertEq (rev "racecar") "racecar")
+  , test "an even-sized word"          (assertEq (rev "drawer") "reward")
+  , test "wide characters"             (assertEq (rev "子猫") "猫子")
+--  , test "grapheme cluster with pre-combined form" (assertEq (rev "Würstchenstand") "dnatsnehctsrüW")
+--  , test "grapheme clusters"                       (assertEq (rev "ผู้เขียนโปรแกรม") "มรกแรปโนยขีเผู้")
+  ]
+
+export
+main : IO ()
+main = do
+  success <- runTests tests
+  if success
+     then putStrLn "All tests passed"
+     else exitFailure

--- a/exercises/practice/reverse-string/test/test.ipkg
+++ b/exercises/practice/reverse-string/test/test.ipkg
@@ -1,0 +1,6 @@
+package reverse-string-test
+depends = reverse-string
+  , tester
+main = Main
+executable = "reverse-string-test"
+sourcedir = "src"


### PR DESCRIPTION
Note that the grapheme cluster test cases fail with my example solution, but they also fail with the `reverse` from [Prelude.Strings](https://www.idris-lang.org/docs/1.0/base_doc/docs/Prelude.Strings.html)

I named the function `rev` to avoid colliding with `reverse`.  Another option would be `reverseString` but we already have `module ReverseString`