### PR TITLE
Rename RNA Transcription

### DIFF
--- a/config.json
+++ b/config.json
@@ -82,7 +82,7 @@
       },
       {
         "slug": "rna-transcription",
-        "name": "Rna Transcription",
+        "name": "RNA Transcription",
         "uuid": "3640da6c-4f1d-483c-8990-de225fcb0b03",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
Now all practice exercises have names consistent with problem-specifications metadata

https://github.com/exercism/problem-specifications/blob/main/exercises/rna-transcription/metadata.toml

[no important files changed]