### PR TITLE
Link to Idris 2 docs instead of Idris 1

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -43,7 +43,7 @@ brew install chezscheme
 
 ```
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/stefan-hoeck/idris2-pack/main/install.bash)"
-export PATH="$HOME/.pack/bin:$HOME/.idris2/bin:$PATH"
+export PATH="$HOME/.pack/bin:$PATH"
 pack info
 ```
 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,6 +1,6 @@
 # Learning
 
-- [The official documentation](https://docs.idris-lang.org/en/latest/index.html)
+- [The official documentation](https://idris2.readthedocs.io/en/latest/)
 
 This tutorial is intended as a brief introduction to the language,
 and is aimed at readers already familiar with a functional language such as Haskell or OCaml.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,6 +1,6 @@
 # Useful resources
 
-- The [official homepage](https://www.idris-lang.org/) and [documentation](https://docs.idris-lang.org/en/latest/index.html)
+- The [official homepage](https://www.idris-lang.org/) and [documentation](https://idris2.readthedocs.io/en/latest/)
 - [Type-Driven Development with Idris](https://www.manning.com/books/type-driven-development-with-idris), with [updates](https://idris2.readthedocs.io/en/latest/typedd/typedd.html)
 - The [Github repository](https://github.com/idris-lang/Idris-dev)
   containing compiler and libraries.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -2,8 +2,8 @@
 
 - The [official homepage](https://www.idris-lang.org/) and [documentation](https://idris2.readthedocs.io/en/latest/)
 - [Type-Driven Development with Idris](https://www.manning.com/books/type-driven-development-with-idris), with [updates](https://idris2.readthedocs.io/en/latest/typedd/typedd.html)
-- The [Github repository](https://github.com/idris-lang/Idris-dev)
+- The [Github repository](https://github.com/idris-lang/Idris2)
   containing compiler and libraries.
-- The [wiki](https://github.com/idris-lang/Idris-dev/wiki)
+- The [wiki](https://github.com/idris-lang/Idris2/wiki)
 - The [mailing list](https://groups.google.com/forum/#!forum/idris-lang)
 - The IRC channel `#idris` on freenode


### PR DESCRIPTION
From forum

https://forum.exercism.org/t/incorrect-links-on-how-to-learn-idris/17959/

http://forum.exercism.org/t/osx-installation-of-idris/17941/4
